### PR TITLE
Fix bug of deleting failure of udp port

### DIFF
--- a/commands
+++ b/commands
@@ -77,7 +77,7 @@ case "$1" in
 
     echo "-----> Unbinding port $CONTAINER_PORT in $APP"
     BIND_TEMP=`cat "$BIND_FILE"`
-    BIND_TEMP=$(echo "$BIND_TEMP" | sed "s/^.*:$CONTAINER_PORT$//")
+    BIND_TEMP=$(echo "$BIND_TEMP" | sed "s|^.*:$CONTAINER_PORT$||")
     echo "$BIND_TEMP" | sed '/^$/d' | sort -u > $BIND_FILE
     bind_restart_app $APP
   ;;


### PR DESCRIPTION
When I tried to delete udp binding port, I got the following error.

```
-----> Unbinding port 12345/udp in app-name
sed: -e expression #1, char 18: unknown option to `s'
```

This PR will fix it.
